### PR TITLE
isSupported should return NO on iOS Simulator

### DIFF
--- a/ios/src/main/objectivec/com_codename1_ext_codescan_NativeCodeScannerImpl.m
+++ b/ios/src/main/objectivec/com_codename1_ext_codescan_NativeCodeScannerImpl.m
@@ -38,7 +38,11 @@
 }
 
 -(BOOL)isSupported{
+#if !TARGET_IPHONE_SIMULATOR
     return YES;
+#else
+    return NO;
+#endif
 }
 
 @end


### PR DESCRIPTION
The iOS implementation does nothing if it detects it is running on the iOS simulator. `isSupported` should therefore return `NO`, allowing calling code to choose an alternative solution.